### PR TITLE
Fix loop scheduling

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -131,12 +131,12 @@ class GLPlayer {
 
     if (song.looped) {
       const loopTime = song.duration * tempoFactor + startOffset;
-      Tone.Transport.scheduleRepeat(() => {
-        this.players.forEach(p => p.player.start(startOffset));
+      Tone.Transport.scheduleRepeat((time) => {
+        this.players.forEach(p => p.player.start(time + startOffset));
         if (this.countInPlayer) {
-          this.countInPlayer.start(0);
+          this.countInPlayer.start(time);
         }
-      }, loopTime);
+      }, loopTime, startOffset);
     }
 
     Tone.Transport.start();


### PR DESCRIPTION
## Summary
- fix `scheduleRepeat` to accept `time` argument and start tracks with `time + startOffset`
- pass `startOffset` as the schedule start time
- start the count‑in at the scheduled time within the repeat callback

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684b080323e4832daf41dfd917902d9b