### PR TITLE
Update count-in playback handling

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -61,7 +61,7 @@ class GLPlayer {
     const volumeNodes = [];
     this.players = [];
     if (song.countIn) {
-      const player = new Tone.Player({ url: song.countIn.url, loop: song.looped }).toDestination();
+      const player = new Tone.Player({ url: song.countIn.url, loop: false }).toDestination();
       player.autostart = false;
       this.countInPlayer = player;
     } else {
@@ -130,13 +130,10 @@ class GLPlayer {
     });
 
     if (song.looped) {
-      const loopTime = song.duration * tempoFactor + startOffset;
+      const loopTime = song.duration * tempoFactor;
       Tone.Transport.scheduleRepeat((time) => {
-        this.players.forEach(p => p.player.start(time + startOffset));
-        if (this.countInPlayer) {
-          this.countInPlayer.start(time);
-        }
-      }, loopTime, startOffset);
+        this.players.forEach(p => p.player.start(time));
+      }, loopTime, startOffset + loopTime);
     }
 
     Tone.Transport.start();


### PR DESCRIPTION
## Summary
- ensure count-in player never loops
- avoid restarting the count-in every loop
- fix loop schedule so repeats use track duration, not count-in length

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c1ec02f60832d8fbc63700c67e8c2